### PR TITLE
Fix for GHC 7.8

### DIFF
--- a/Data/Hex/Quote.hs
+++ b/Data/Hex/Quote.hs
@@ -81,7 +81,7 @@ mkExtract (Lit xs : ts) = let n = length xs in
     [| \x -> case B.splitAt n x of
                  (y,z) | B.unpack y == $(liftBS xs) -> $(mkExtract ts) z
                        | otherwise -> Nothing |]
-mkExtract (Take _ (Just n) : ts) = let nn = fromIntegral n in
+mkExtract (Take _ (Just n) : ts) = let nn = fromIntegral n :: Int in
     [| \x -> case B.splitAt nn x of
                  (y,z) | B.length y == nn -> (y:) <$> $(mkExtract ts) z
                        | otherwise -> Nothing |]


### PR DESCRIPTION
Since GHC 7.8, TH expressions aren't type checked at all, so the inference
engine can't pick up the Int-constraint on nn, leading to ambiguity
errors.
